### PR TITLE
Remove whitespace before php tag

### DIFF
--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -68,8 +68,7 @@ if ( ! function_exists( 'haste_starter_the_container' ) ) {
 			</div>
 
 		<?php } ?>
-	<?php } ?>
-	<?php
+	<?php }
 }
 
 if ( ! function_exists( 'haste_starter_open_content_wrapper' ) ) {


### PR DESCRIPTION
This whitespace was writing on output before the headers, issuing an error:

```
Warning: Cannot modify header information - headers already sent by (output started at /var/www/html/wp-content/themes/avodaq/inc/template-tags.php:72) in /var/www/html/wp-includes/functions.php on line 6584 Warning: Cannot modify header information - headers already sent by (output started at /var/www/html/wp-content/themes/avodaq/inc/template-tags.php:72) in /var/www/html/wp-admin/includes/misc.php on line 1310 Warning: Cannot modify header information - headers already sent by (output started at /var/www/html/wp-content/themes/avodaq/inc/template-tags.php:72) in /var/www/html/wp-admin/admin-header.php on line 9 Warning: Cannot modify header information - headers already sent by (output started at /var/www/html/wp-content/themes/avodaq/inc/template-tags.php:72) in /var/www/html/wp-includes/option.php on line 1097 Warning: Cannot modify header information - headers already sent by (output started at /var/www/html/wp-content/themes/avodaq/inc/template-tags.php:72) in /var/www/html/wp-includes/option.php on line 1098 
```